### PR TITLE
Update the ingest message struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/Shopify/sarama v1.32.0
 	github.com/pkg/errors v0.8.1
+	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/wasp/video-message-transform.go
+++ b/wasp/video-message-transform.go
@@ -7,7 +7,7 @@ type IngestMessage struct {
 	Timestamp string                 `json:"timestamp"`
 	Payload   string                 `json:"payload"`
 	Metadata  map[string]interface{} `json:"metadata"`
-	ThingID   string                 `json:"thingID"`
+	ThingID   string                 `json:"thingId"`
 	Type      string                 `json:"type"`
 }
 

--- a/wasp/video-message-transform.go
+++ b/wasp/video-message-transform.go
@@ -1,5 +1,11 @@
 package wasp
 
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
 // IngestMessage defines the video ingest message structure
 type IngestMessage struct {
 	Ingest    string                 `json:"ingest"`
@@ -17,16 +23,36 @@ type OutputMessage struct {
 	Type      string
 	Timestamp string
 	Value     string
-	Metadata  string
+	Metadata  map[string]interface{}
 }
 
 // TransformVideoMessages processes the messages as part of the message relay
 func TransformVideoMessages(msg []byte) ([]byte, error) {
 	// Transform messages here
 	// Unmarshal
+	var (
+		ingest = &IngestMessage{}
+		err    error
+	)
+
+	if err = json.Unmarshal(msg, ingest); err != nil {
+		return nil, errors.Wrap(err, "unable to unmarshal ingest")
+	}
 	// Modify values
 	// Create new message
+	output := &OutputMessage{
+		ThingID:   ingest.ThingID,
+		Type:      ingest.Type,
+		Timestamp: ingest.Timestamp,
+		Value:     ingest.Payload,
+		Metadata:  ingest.Metadata,
+	}
 	// Marshal
+	outputMsg, err := json.Marshal(output)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal output message")
+	}
+
 	// return
-	return msg, nil
+	return outputMsg, nil
 }

--- a/wasp/video-message-transform.go
+++ b/wasp/video-message-transform.go
@@ -2,11 +2,13 @@ package wasp
 
 // IngestMessage defines the video ingest message structure
 type IngestMessage struct {
-	Ingest    string `json:"ingest"`
-	IngestID  string `json:"ingestId"`
-	Timestamp string `json:"timestamp"`
-	Payload   string `json:"payload"`
-	Metadata  string `json:"metadata"`
+	Ingest    string                 `json:"ingest"`
+	IngestID  string                 `json:"ingestId"`
+	Timestamp string                 `json:"timestamp"`
+	Payload   string                 `json:"payload"`
+	Metadata  map[string]interface{} `json:"metadata"`
+	ThingID   string                 `json:"thingID"`
+	Type      string                 `json:"type"`
 }
 
 // OutputMessage defines the output message structure

--- a/wasp/video-message-transform_test.go
+++ b/wasp/video-message-transform_test.go
@@ -1,0 +1,43 @@
+package wasp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/digicatapult/wasp-simple-h264-payload-parser/wasp"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformVideoMessage(t *testing.T) {
+	ingest := &wasp.IngestMessage{
+		Ingest:    uuid.NewV4().String(),
+		IngestID:  uuid.NewV4().String(),
+		Timestamp: uuid.NewV4().String(),
+		Payload:   uuid.NewV4().String(),
+		ThingID:   uuid.NewV4().String(),
+		Type:      uuid.NewV4().String(),
+		Metadata: map[string]interface{}{
+			uuid.NewV4().String(): uuid.NewV4().String(),
+		},
+	}
+
+	msgBytes, err := json.Marshal(ingest)
+	require.NoError(t, err)
+
+	outputBytes, err := wasp.TransformVideoMessages(msgBytes)
+	require.NoError(t, err)
+
+	output := &wasp.OutputMessage{}
+
+	err = json.Unmarshal(outputBytes, output)
+	require.NoError(t, err)
+
+	assert.Equal(t, ingest.ThingID, output.ThingID)
+	assert.Equal(t, ingest.Type, output.Type)
+	assert.Equal(t, ingest.Payload, output.Value)
+	assert.Equal(t, ingest.Timestamp, output.Timestamp)
+	assert.Equal(t, ingest.ThingID, output.ThingID)
+	assert.Equal(t, ingest.Metadata, output.Metadata)
+}

--- a/wasp/video-message-transform_test.go
+++ b/wasp/video-message-transform_test.go
@@ -5,22 +5,19 @@ import (
 	"testing"
 
 	"github.com/digicatapult/wasp-simple-h264-payload-parser/wasp"
-	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTransformVideoMessage(t *testing.T) {
 	ingest := &wasp.IngestMessage{
-		Ingest:    uuid.NewV4().String(),
-		IngestID:  uuid.NewV4().String(),
-		Timestamp: uuid.NewV4().String(),
-		Payload:   uuid.NewV4().String(),
-		ThingID:   uuid.NewV4().String(),
-		Type:      uuid.NewV4().String(),
-		Metadata: map[string]interface{}{
-			uuid.NewV4().String(): uuid.NewV4().String(),
-		},
+		ThingID:   "883d818a-e115-4b99-b264-bb2033de21f1",
+		Type:      "h264",
+		Ingest:    "ingest-rtmp",
+		IngestID:  "APP/STREAM",
+		Payload:   "bytes",
+		Timestamp: "2021-03-23 00:00:00", // iso date example
+		Metadata:  map[string]interface{}{},
 	}
 
 	msgBytes, err := json.Marshal(ingest)
@@ -38,6 +35,5 @@ func TestTransformVideoMessage(t *testing.T) {
 	assert.Equal(t, ingest.Type, output.Type)
 	assert.Equal(t, ingest.Payload, output.Value)
 	assert.Equal(t, ingest.Timestamp, output.Timestamp)
-	assert.Equal(t, ingest.ThingID, output.ThingID)
 	assert.Equal(t, ingest.Metadata, output.Metadata)
 }


### PR DESCRIPTION
**Problem**
Our ingest message struct for the payload processor does not match the exact format that will be received from the routing service. We need to update the ingest message struct.

**Solution**
- [x] Update the ingest message struct to add new fields.
- [x] Populate the output message struct from the input