### PR TITLE
Pass payload as a struct

### DIFF
--- a/wasp/video-message-transform.go
+++ b/wasp/video-message-transform.go
@@ -11,7 +11,7 @@ type IngestMessage struct {
 	Ingest    string                 `json:"ingest"`
 	IngestID  string                 `json:"ingestId"`
 	Timestamp string                 `json:"timestamp"`
-	Payload   string                 `json:"payload"`
+	Payload   *Payload               `json:"payload"`
 	Metadata  map[string]interface{} `json:"metadata"`
 	ThingID   string                 `json:"thingId"`
 	Type      string                 `json:"type"`
@@ -22,8 +22,18 @@ type OutputMessage struct {
 	ThingID   string
 	Type      string
 	Timestamp string
-	Value     string
+	Value     *Payload
 	Metadata  map[string]interface{}
+}
+
+// Payload defines the data contained in
+type Payload struct {
+	ID          string
+	FrameNo     int
+	Filename    string
+	Type        string
+	Data        []byte `json:"-"`
+	EncodedData string `json:"Data"`
 }
 
 // TransformVideoMessages processes the messages as part of the message relay

--- a/wasp/video-message-transform.go
+++ b/wasp/video-message-transform.go
@@ -33,7 +33,7 @@ type Payload struct {
 	Filename    string
 	Type        string
 	Data        []byte `json:"-"`
-	EncodedData string `json:"Data"`
+	EncodedData string `json:"data"`
 }
 
 // TransformVideoMessages processes the messages as part of the message relay


### PR DESCRIPTION
**Problem**
Passing the payload as a string creates problems when unmarshalling in the stream service.

**Solution**
Pass the payload as it's first class struct type and then we can unmarshal it in the stream service